### PR TITLE
move cpack config from Tutorial1 to main CMakeLists.txt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,11 +74,18 @@ build_script:
   #- cmake --build ./build --target PACKAGE --config %configuration% -- /nologo
 
 after_build:
-  - cd C:\projects\build
+  # set compiler var
   - if "%generator%"=="Visual Studio 14" (set COMPILER="VC14")
   - if "%generator%"=="MinGW Makefiles"  (set COMPILER="MinGW") 
+  # copy required system libraries from \bin folder into \Tutorials1 folder
+  - xcopy C:\projects\build\tutorials\bin\*.* C:\projects\build\tutorials\Tutorial1
+  - rd /s /q C:\projects\build\tutorials\bin
+  # switch to project build folder and zip "tutorials" folder
+  - cd C:\projects\build
   - 7z a -tzip -mx9 "tutorials-%APPVEYOR_BUILD_VERSION%-%COMPILER%.zip" tutorials
+  # switch to project directory and zip append the "assets" folder
   - cd %APPVEYOR_BUILD_FOLDER%
   - 7z a -tzip -mx9 "C:\projects\build\tutorials-%APPVEYOR_BUILD_VERSION%-%COMPILER%.zip" assets
+  # finally, push the tutorials artifact
   - cd C:\projects\build
   - appveyor PushArtifact "tutorials-%APPVEYOR_BUILD_VERSION%-%COMPILER%.zip"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,3 +102,33 @@ set(Boost_USE_MULTITHREADED ON)
 #------------------------------------------------------------------------------
 
 add_subdirectory(tutorial_1)
+
+#------------------------------------------------------------------------------
+#                            Package Tutorials
+#------------------------------------------------------------------------------
+
+# include system runtimes (e.g. msvcp140.dll) into "<install_prefix>/bin" folder 
+# how can i change/remove the "bin" suffix to install into <install_prefix>?
+include(InstallRequiredSystemLibraries)
+
+# set package type depending on OS
+#if(WIN32)
+#  set(CPACK_GENERATOR ${CPACK_GENERATOR} ZIP)
+#elseif(APPLE)
+#  set(CPACK_GENERATOR ${CPACK_GENERATOR} DragNDrop)
+#else()
+#  set(CPACK_GENERATOR ${CPACK_GENERATOR} TGZ)
+#endif()
+
+#set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
+
+# tell CPack all of the components to install..
+#set(CPACK_COMPONENTS_ALL executable libraries)
+
+#set(CPACK_MONOLITHIC_INSTALL on)
+
+# tell cpack to strip debug symbols from files
+#set(CPACK_STRIP_FILES 1)
+
+# this must be the last call
+#include(CPack)

--- a/src/tutorial_1/CMakeLists.txt
+++ b/src/tutorial_1/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 project(Tutorial1)
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.6)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules)
 
@@ -96,30 +96,5 @@ install(CODE "
    COMPONENT libraries
 )
 
-#------------------------------------------------------------------------------
-#                         Package Tutorial 1                                        
-#------------------------------------------------------------------------------
 
-# set package type depending on OS
-#if(WIN32)
-#  set(CPACK_GENERATOR ZIP)
-#elseif(APPLE)
-#  set(CPACK_GENERATOR DragNDrop)
-#else()
-#  set(CPACK_GENERATOR TGZ)
-#endif()
 
-# include system runtimes (e.g. msvcp140.dll) into "<install_prefix>/bin" folder 
-# how can i change/remove the "bin" suffix to install into <install_prefix>?
-#include(InstallRequiredSystemLibraries)
-
-#set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
-
-# tell CPack all of the components to install..
-#set(CPACK_COMPONENTS_ALL executable libraries)
-
-# tell cpack to strip debug symbols from files
-#set(CPACK_STRIP_FILES           1)
-
-# this must be the last call
-#include(CPack)


### PR DESCRIPTION
use include(InstallRequiredSystemLibraries) to copy system libs into /bin folder
copy system libs into /tutorial1 folder
issue https://github.com/fifengine/cpp-tutorials/issues/13
